### PR TITLE
Fix install script errors, partial fix for failing tests

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
+if [ "$EUID" -ne 0 ]; then
+    echo "This script requires root to run, use sudo $0"
+    exit 1
+fi
+
 if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-  apt install python3-pip python3-dev
-  curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-  apt-get install -y nodejs npm
+  apt-get install -y python3-pip python3-dev
+  curl -sL https://deb.nodesource.com/setup_10.x | bash -
+  apt-get install -y nodejs
 else
   echo "Installation script is only configured for Linux installation";
   exit 1
 fi
 
 # Install IPFS
-apt-get install curl
+apt-get install -y curl
 if [ "$(arch)" == "x86_64" ]; then
   curl -X GET https://dist.ipfs.io/go-ipfs/v0.4.16/go-ipfs_v0.4.16_linux-386.tar.gz > ipfs.tar.gz
 else
@@ -23,8 +28,10 @@ cd go-ipfs
 cd ../
 rm -rf go-ipfs/
 rm ipfs.tar.gz
+
 # Install Pip dependencies
-pip3 install numpy matplotlib web3 ipfshttpclient pyqt5
-pip3 install py-solc
+python3 -m pip install --upgrade pip
+python3 -m pip install numpy matplotlib web3 ipfshttpclient pyqt5 py-solc-x
+
 # Install Ganache
 npm install -g ganache-cli

--- a/lib/bc_admin.py
+++ b/lib/bc_admin.py
@@ -1,4 +1,4 @@
-from web3 import Web3, HTTPProvider,TestRPCProvider
+from web3 import Web3, HTTPProvider
 from Contract import *
 
 '''

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if ! pgrep -f "node /usr/local/bin/ganache-cli" >> /dev/null
+if ! pgrep -f "ganache-cli" >> /dev/null
 then
     echo "Error: You need to have a ganache-cli instance up to run the tests"
     exit -1
@@ -12,9 +12,15 @@ then
     exit -1
 fi
 
+
+# Setup
+mkdir -p ./logs
+python3 -c 'import solcx; solcx.install_solc("v0.4.23")'
+
 # Run tests 
 python3 test/web_trust_test.py -v
 python3 test/PriorityQ_Test.py -v
 python3 test/fw_repo_test.py -v
+
 # Clear temporary files
 ./clear_logs.sh


### PR DESCRIPTION
Issues I encountered:
Installing both nodejs and npm caused a package conflict, installing just nodejs still provides npm
pyqt5 failed to install until pip was updated
Tests failed for the following reasons:
* Missing module: solcx. Replacing py-solc with py-solc-x fixes this
* Attempting to import TestRPCProvider from web3. As this class doesn't seem to be used anywhere I removed it from the import statement.
* solcx throws an exception unless solcx.install_solc() is called at some point before running the tests.
* The logging in fw_repo_test.py was throwing an exception if the ./logs directory didn't exist

Some tests in fw_repo_test.py still fail, I think the underlying cause is Exception: Unsupported daemon version '0.4.16' (not in range: 0.4.22 ≤ … < 0.7.0) thrown by ipfshttpclient